### PR TITLE
Add Material UI home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@mui/material": "^5.15.19",
+    "@emotion/react": "^11.11.5",
+    "@emotion/styled": "^11.11.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,28 @@
 import "./App.css";
+import { Container, Button, Stack, Typography } from "@mui/material";
 
 function App() {
-  return <p>Welcome to Kayzen</p>;
+  return (
+    <Container maxWidth="sm" sx={{ textAlign: "center", py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Kayzen
+      </Typography>
+      <Stack spacing={2}>
+        <Button variant="contained" fullWidth>
+          Pick a Quest
+        </Button>
+        <Button variant="contained" color="secondary" fullWidth>
+          Add New Quest
+        </Button>
+        <Button variant="contained" fullWidth>
+          Accepted Quests
+        </Button>
+        <Button variant="outlined" fullWidth>
+          Settings
+        </Button>
+      </Stack>
+    </Container>
+  );
 }
 
 export default App;


### PR DESCRIPTION
## Summary
- add Material UI packages
- create minimalistic home page with four actions

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@mui/material')*

------
https://chatgpt.com/codex/tasks/task_b_68622723d46483269117e246407a8970